### PR TITLE
feat(work-experience): expose is_current and duration_months in API r…

### DIFF
--- a/app/api/schemas/work_experience_schema.py
+++ b/app/api/schemas/work_experience_schema.py
@@ -114,5 +114,9 @@ class WorkExperienceResponse(WorkExperienceBase, TimestampMixin):
     """
 
     id: str
+    is_current: bool = Field(
+        ..., description="True si es la posición actual (sin fecha de fin)"
+    )
+    duration_months: int = Field(..., ge=0, description="Duración en meses completos")
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/application/dto/work_experience_dto.py
+++ b/app/application/dto/work_experience_dto.py
@@ -66,10 +66,15 @@ class WorkExperienceResponse:
     created_at: datetime
     updated_at: datetime
     is_current: bool
+    duration_months: int
 
     @classmethod
     def from_entity(cls, entity) -> "WorkExperienceResponse":
         """Create DTO from domain entity."""
+        start = entity.start_date
+        end = entity.end_date if entity.end_date is not None else datetime.utcnow()
+        duration_months = (end.year - start.year) * 12 + (end.month - start.month)
+
         return cls(
             id=entity.id,
             profile_id=entity.profile_id,
@@ -83,6 +88,7 @@ class WorkExperienceResponse:
             created_at=entity.created_at,
             updated_at=entity.updated_at,
             is_current=entity.is_current_position(),
+            duration_months=duration_months,
         )
 
 

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -121,6 +121,10 @@ YESTERDAY = NOW - timedelta(days=1)
 LAST_WEEK = NOW - timedelta(days=7)
 PROFILE_ID = "default_profile"
 
+_EXP_001_START = datetime(2022, 1, 1)
+_EXP_002_START = datetime(2020, 6, 1)
+_EXP_002_END = datetime(2021, 12, 31)
+
 # -- Profile --
 MOCK_PROFILE = ProfileDTO(
     id="profile_001",
@@ -216,7 +220,7 @@ MOCK_EXPERIENCES = [
         profile_id=PROFILE_ID,
         role="Senior Developer",
         company="Tech Corp",
-        start_date=datetime(2022, 1, 1),
+        start_date=_EXP_001_START,
         end_date=None,
         description="Leading backend development",
         responsibilities=["Architecture", "Code review"],
@@ -224,20 +228,24 @@ MOCK_EXPERIENCES = [
         created_at=NOW,
         updated_at=NOW,
         is_current=True,
+        duration_months=(NOW.year - _EXP_001_START.year) * 12
+        + (NOW.month - _EXP_001_START.month),
     ),
     WorkExperienceDTO(
         id="exp_002",
         profile_id=PROFILE_ID,
         role="Junior Developer",
         company="StartUp Inc",
-        start_date=datetime(2020, 6, 1),
-        end_date=datetime(2021, 12, 31),
+        start_date=_EXP_002_START,
+        end_date=_EXP_002_END,
         description="Full stack development",
         responsibilities=["Frontend", "Backend"],
         order_index=1,
         created_at=NOW,
         updated_at=NOW,
         is_current=False,
+        duration_months=(_EXP_002_END.year - _EXP_002_START.year) * 12
+        + (_EXP_002_END.month - _EXP_002_START.month),
     ),
 ]
 

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -206,13 +206,17 @@ MOCK_EDUCATION = [
 ]
 
 # -- Work Experiences --
+_EXP_001_START = datetime(2022, 1, 1)
+_EXP_002_START = datetime(2020, 6, 1)
+_EXP_002_END = datetime(2021, 12, 31)
+
 MOCK_EXPERIENCES = [
     WorkExperienceDTO(
         id="exp_001",
         profile_id=PROFILE_ID,
         role="Senior Developer",
         company="Tech Corp",
-        start_date=datetime(2022, 1, 1),
+        start_date=_EXP_001_START,
         end_date=None,
         description="Leading backend development",
         responsibilities=["Architecture", "Code review"],
@@ -220,20 +224,24 @@ MOCK_EXPERIENCES = [
         created_at=NOW,
         updated_at=NOW,
         is_current=True,
+        duration_months=(NOW.year - _EXP_001_START.year) * 12
+        + (NOW.month - _EXP_001_START.month),
     ),
     WorkExperienceDTO(
         id="exp_002",
         profile_id=PROFILE_ID,
         role="Junior Developer",
         company="StartUp Inc",
-        start_date=datetime(2020, 6, 1),
-        end_date=datetime(2021, 12, 31),
+        start_date=_EXP_002_START,
+        end_date=_EXP_002_END,
         description="Full stack development",
         responsibilities=["Frontend", "Backend"],
         order_index=1,
         created_at=NOW,
         updated_at=NOW,
         is_current=False,
+        duration_months=(_EXP_002_END.year - _EXP_002_START.year) * 12
+        + (_EXP_002_END.month - _EXP_002_START.month),
     ),
 ]
 

--- a/tests/unit/application/dto/test_work_experience_dto.py
+++ b/tests/unit/application/dto/test_work_experience_dto.py
@@ -1,5 +1,9 @@
 """Tests for WorkExperience DTOs."""
 
+from datetime import datetime
+
+import pytest
+
 from app.application.dto.work_experience_dto import (
     WorkExperienceListResponse,
     WorkExperienceResponse,
@@ -69,6 +73,72 @@ class TestWorkExperienceResponseFromEntity:
         entity = _make_experience_entity(responsibilities=[])
         resp = WorkExperienceResponse.from_entity(entity)
         assert resp.responsibilities == []
+
+
+class TestWorkExperienceResponseDurationMonths:
+    """Tests for duration_months calculation in WorkExperienceResponse.from_entity()."""
+
+    def test_closed_position_exact_months(self):
+        """Closed position with a fixed date range returns exact month count."""
+        start = datetime(2023, 1, 1)
+        end = datetime(2023, 7, 1)  # 6 months
+        entity = _make_experience_entity(start_date=start, end_date=end)
+        resp = WorkExperienceResponse.from_entity(entity)
+        assert resp.duration_months == 6
+
+    def test_closed_position_exactly_one_month(self):
+        """Closed position spanning exactly one calendar month."""
+        start = datetime(2023, 3, 1)
+        end = datetime(2023, 4, 1)  # 1 month
+        entity = _make_experience_entity(start_date=start, end_date=end)
+        resp = WorkExperienceResponse.from_entity(entity)
+        assert resp.duration_months == 1
+
+    def test_closed_position_exactly_twelve_months(self):
+        """Closed position spanning exactly 12 months (one year)."""
+        start = datetime(2022, 1, 1)
+        end = datetime(2023, 1, 1)  # 12 months
+        entity = _make_experience_entity(start_date=start, end_date=end)
+        resp = WorkExperienceResponse.from_entity(entity)
+        assert resp.duration_months == 12
+
+    @pytest.mark.unit
+    def test_current_position_duration_greater_than_zero(self):
+        """Active position (end_date=None) computes duration up to today, which is > 0."""
+        # A start date far in the past guarantees duration > 0 regardless of test date.
+        start = datetime(2020, 1, 1)
+        entity = _make_experience_entity(
+            start_date=start, end_date=None, _is_current=True
+        )
+        resp = WorkExperienceResponse.from_entity(entity)
+        assert resp.duration_months > 0
+
+    @pytest.mark.unit
+    def test_current_position_duration_reflects_months_to_now(self):
+        """Active position duration equals months from start_date to the current month."""
+        start = datetime(2020, 6, 1)
+        entity = _make_experience_entity(
+            start_date=start, end_date=None, _is_current=True
+        )
+        resp = WorkExperienceResponse.from_entity(entity)
+
+        now = datetime.utcnow()
+        expected = (now.year - start.year) * 12 + (now.month - start.month)
+        assert resp.duration_months == expected
+
+    @pytest.mark.unit
+    def test_is_current_true_when_no_end_date(self):
+        """is_current is True when end_date is None."""
+        entity = _make_experience_entity(end_date=None, _is_current=True)
+        resp = WorkExperienceResponse.from_entity(entity)
+        assert resp.is_current is True
+
+    @pytest.mark.unit
+    def test_is_current_false_when_has_end_date(self):
+        """is_current is False when end_date is set."""
+        entity = _make_experience_entity(end_date=DT_END, _is_current=False)
+        resp = WorkExperienceResponse.from_entity(entity)
+        assert resp.is_current is False
 
 
 class TestWorkExperienceListResponseFromEntities:


### PR DESCRIPTION
…esponse

Add duration_months (whole calendar months) computed field to WorkExperienceDTO.from_entity(), using end_date or datetime.utcnow() for active positions. Expose is_current and duration_months in WorkExperienceResponse schema — both fields existed in the DTO but were never declared in the Pydantic schema. Closes #152 (backend tasks).