### PR TITLE
fix(work-experience): propagate location field through POST and PUT c…

### DIFF
--- a/app/api/v1/routers/work_experience_router.py
+++ b/app/api/v1/routers/work_experience_router.py
@@ -83,6 +83,7 @@ async def create_work_experience(
             order_index=experience_data.order_index,
             description=experience_data.description,
             end_date=experience_data.end_date,
+            location=experience_data.location,
             responsibilities=experience_data.responsibilities or [],
         )
     )
@@ -106,6 +107,7 @@ async def update_work_experience(
             role=experience_data.role,
             company=experience_data.company,
             description=experience_data.description,
+            location=experience_data.location,
             start_date=experience_data.start_date,
             end_date=experience_data.end_date,
             responsibilities=experience_data.responsibilities,

--- a/app/application/use_cases/work_experience/add_experience.py
+++ b/app/application/use_cases/work_experience/add_experience.py
@@ -72,6 +72,7 @@ class AddExperienceUseCase(
             order_index=request.order_index,
             description=request.description,
             end_date=request.end_date,
+            location=request.location,
             responsibilities=request.responsibilities,
         )
 

--- a/app/application/use_cases/work_experience/edit_experience.py
+++ b/app/application/use_cases/work_experience/edit_experience.py
@@ -63,6 +63,7 @@ class EditExperienceUseCase(
             role=request.role,
             company=request.company,
             description=request.description,
+            location=request.location,
             start_date=request.start_date,
             end_date=request.end_date,
         )


### PR DESCRIPTION
…hain

fix(work-experience): propagate location field through POST and PUT chain

location was accepted by the schema and DTO but never forwarded to AddExperienceRequest, WorkExperience.create(), EditExperienceRequest, nor update_info(), causing it to always persist as null.