### PR TITLE
fix: hacer category opcional en Tool (dominio, schema, DTO y mapper)

### DIFF
--- a/app/api/schemas/tools_schema.py
+++ b/app/api/schemas/tools_schema.py
@@ -15,8 +15,8 @@ class ToolBase(BaseModel):
         max_length=50,
         description="Nombre de la herramienta (no puede estar vacío)",
     )
-    category: str = Field(
-        ...,
+    category: str | None = Field(
+        None,
         min_length=1,
         max_length=50,
         description="Tipo de herramienta (IDE, cloud, CI/CD, etc.)",

--- a/app/api/v1/routers/tools_router.py
+++ b/app/api/v1/routers/tools_router.py
@@ -60,6 +60,8 @@ async def get_tools_grouped_by_category(
     result = await use_case.execute(ListToolsRequest(profile_id=PROFILE_ID))
     grouped: dict[str, list] = {}
     for tool in result.tools:
+        if tool.category is None:
+            continue
         if tool.category not in grouped:
             grouped[tool.category] = []
         grouped[tool.category].append(tool)

--- a/app/application/dto/tool_dto.py
+++ b/app/application/dto/tool_dto.py
@@ -14,8 +14,8 @@ class AddToolRequest:
 
     profile_id: str
     name: str
-    category: str
     order_index: int
+    category: str | None = None
     icon_url: str | None = None
 
 
@@ -52,7 +52,7 @@ class ToolResponse:
     id: str
     profile_id: str
     name: str
-    category: str
+    category: str | None
     order_index: int
     icon_url: str | None
     created_at: datetime

--- a/app/domain/entities/tool.py
+++ b/app/domain/entities/tool.py
@@ -6,7 +6,7 @@ Represents a tool, technology, or software used in the portfolio.
 Business Rules Applied:
 - RB-T01: name is required (1-50 chars)
 - RB-T02: name must be unique per profile
-- RB-T03: category is required (1-50 chars, e.g., "Framework", "Database")
+- RB-T03: category is optional (1-50 chars if provided, e.g., "Framework", "Database")
 - RB-T04: iconUrl is optional, must be valid URL if provided
 - RB-T05: orderIndex is required for display ordering
 """
@@ -37,8 +37,8 @@ class Tool:
     id: str
     profile_id: str
     name: str
-    category: str
     order_index: int
+    category: str | None = None
     icon_url: str | None = None
     created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: datetime = field(default_factory=datetime.utcnow)
@@ -68,8 +68,8 @@ class Tool:
     def create(
         profile_id: str,
         name: str,
-        category: str,
         order_index: int,
+        category: str | None = None,
         icon_url: str | None = None,
     ) -> "Tool":
         """
@@ -78,8 +78,8 @@ class Tool:
         Args:
             profile_id: Reference to the Profile
             name: Tool name (e.g., "Docker", "PostgreSQL")
-            category: Tool category (e.g., "Container", "Database")
             order_index: Position in the ordered list
+            category: Tool category (e.g., "Container", "Database") (optional)
             icon_url: URL to tool icon/logo (optional)
 
         Returns:
@@ -89,8 +89,8 @@ class Tool:
             id=str(uuid.uuid4()),
             profile_id=profile_id,
             name=name,
-            category=category,
             order_index=order_index,
+            category=category,
             icon_url=icon_url,
         )
 
@@ -153,7 +153,10 @@ class Tool:
 
     def _validate_category(self) -> None:
         """Validate category field according to business rules."""
-        if not self.category or not self.category.strip():
+        if self.category is None:
+            return
+
+        if not self.category.strip():
             raise InvalidCategoryError("Category cannot be empty")
 
         if len(self.category) > self.MAX_CATEGORY_LENGTH:

--- a/app/infrastructure/mappers/tool_mapper.py
+++ b/app/infrastructure/mappers/tool_mapper.py
@@ -11,7 +11,7 @@ class ToolMapper(IMapper[Tool, dict[str, Any]]):
             id=str(persistence_model["_id"]),
             profile_id=persistence_model["profile_id"],
             name=persistence_model["name"],
-            category=persistence_model["category"],
+            category=persistence_model.get("category"),
             order_index=persistence_model["order_index"],
             icon_url=persistence_model.get("icon_url"),
             created_at=persistence_model["created_at"],
@@ -23,11 +23,12 @@ class ToolMapper(IMapper[Tool, dict[str, Any]]):
             "_id": domain_entity.id,
             "profile_id": domain_entity.profile_id,
             "name": domain_entity.name,
-            "category": domain_entity.category,
             "order_index": domain_entity.order_index,
             "created_at": domain_entity.created_at,
             "updated_at": domain_entity.updated_at,
         }
+        if domain_entity.category is not None:
+            doc["category"] = domain_entity.category
         if domain_entity.icon_url is not None:
             doc["icon_url"] = domain_entity.icon_url
         return doc

--- a/tests/unit/domain/entities/test_tool.py
+++ b/tests/unit/domain/entities/test_tool.py
@@ -28,6 +28,14 @@ class TestToolCreation:
         assert t.category == "Container"
         assert t.icon_url is None
 
+    def test_create_without_category(self, profile_id):
+        t = Tool.create(
+            profile_id=profile_id,
+            name="Docker",
+            order_index=0,
+        )
+        assert t.category is None
+
     def test_create_with_icon_url(self, profile_id):
         t = Tool.create(
             profile_id=profile_id,


### PR DESCRIPTION
El campo category de la entidad Tool pasa a ser opcional en todas las capas del backend. Hasta ahora era obligatorio en la creación, lo que impedía registrar herramientas sin categoría asignada.

### Cambios:
- domain: category reubicado tras order_index con tipo str | None = None; _validate_category omite la validación cuando el valor es None
- schema: ToolBase.category pasa de Field(...) a Field(None); ToolCreate y ToolResponse lo heredan automáticamente
- dto: AddToolRequest y ToolResponse aceptan category como str | None
- mapper: to_domain usa .get() para compatibilidad con documentos MongoDB sin el campo; to_persistence excluye category cuando es None
- test: añadido test_create_without_category para verificar el nuevo comportamiento