### PR TITLE
fix(work-experience): forward technologies field from router to use case

### DIFF
--- a/app/api/v1/routers/work_experience_router.py
+++ b/app/api/v1/routers/work_experience_router.py
@@ -111,6 +111,7 @@ async def update_work_experience(
             start_date=experience_data.start_date,
             end_date=experience_data.end_date,
             responsibilities=experience_data.responsibilities,
+            technologies=experience_data.technologies,
         )
     )
     return result

--- a/tests/unit/api/test_work_experience_router.py
+++ b/tests/unit/api/test_work_experience_router.py
@@ -67,6 +67,41 @@ class TestUpdateExperience:
         response = await client.put(f"{PREFIX}/nonexistent", json=payload)
         assert response.status_code == 404
 
+    async def test_update_technologies_forwarded_to_use_case(
+        self, client: AsyncClient
+    ):
+        """Regression: technologies must be forwarded from the request body to
+        EditExperienceRequest, not silently dropped by the router."""
+        from unittest.mock import AsyncMock
+
+        from app.api.dependencies import get_edit_experience_use_case
+        from app.application.dto import EditExperienceRequest
+        from app.main import app as fastapi_app
+        from tests.unit.api.conftest import MOCK_EXPERIENCES
+
+        captured: list[EditExperienceRequest] = []
+
+        mock_uc = AsyncMock()
+
+        async def execute(request: EditExperienceRequest):
+            captured.append(request)
+            return MOCK_EXPERIENCES[0]
+
+        mock_uc.execute = AsyncMock(side_effect=execute)
+        fastapi_app.dependency_overrides[get_edit_experience_use_case] = (
+            lambda: mock_uc
+        )
+        try:
+            payload = {"technologies": ["FastAPI", "MongoDB", "Docker"]}
+            response = await client.put(f"{PREFIX}/exp_001", json=payload)
+
+            assert response.status_code == 200
+            assert len(captured) == 1
+            assert captured[0].technologies == ["FastAPI", "MongoDB", "Docker"]
+        finally:
+            # Restore the default override set by conftest autouse fixture
+            del fastapi_app.dependency_overrides[get_edit_experience_use_case]
+
 
 class TestDeleteExperience:
     async def test_delete_returns_success(self, client: AsyncClient):

--- a/tests/unit/api/test_work_experience_router.py
+++ b/tests/unit/api/test_work_experience_router.py
@@ -67,9 +67,7 @@ class TestUpdateExperience:
         response = await client.put(f"{PREFIX}/nonexistent", json=payload)
         assert response.status_code == 404
 
-    async def test_update_technologies_forwarded_to_use_case(
-        self, client: AsyncClient
-    ):
+    async def test_update_technologies_forwarded_to_use_case(self, client: AsyncClient):
         """Regression: technologies must be forwarded from the request body to
         EditExperienceRequest, not silently dropped by the router."""
         from unittest.mock import AsyncMock
@@ -88,9 +86,7 @@ class TestUpdateExperience:
             return MOCK_EXPERIENCES[0]
 
         mock_uc.execute = AsyncMock(side_effect=execute)
-        fastapi_app.dependency_overrides[get_edit_experience_use_case] = (
-            lambda: mock_uc
-        )
+        fastapi_app.dependency_overrides[get_edit_experience_use_case] = lambda: mock_uc
         try:
             payload = {"technologies": ["FastAPI", "MongoDB", "Docker"]}
             response = await client.put(f"{PREFIX}/exp_001", json=payload)


### PR DESCRIPTION
The PUT /work-experiences/:id endpoint was silently dropping the `technologies` field when constructing EditExperienceRequest, so updates to that field were never applied. Added a regression test to prevent recurrence.