### PR TITLE
fix(skills): propagate order_index through PUT update pipeline

### DIFF
--- a/app/api/v1/routers/skill_router.py
+++ b/app/api/v1/routers/skill_router.py
@@ -108,6 +108,7 @@ async def update_skill(
             skill_id=skill_id,
             name=skill_data.name,
             level=skill_data.level,
+            order_index=skill_data.order_index,
         )
     )
     return result

--- a/app/application/dto/skill_dto.py
+++ b/app/application/dto/skill_dto.py
@@ -24,6 +24,7 @@ class EditSkillRequest:
     skill_id: str
     name: str | None = None
     level: str | None = None
+    order_index: int | None = None
 
 
 @dataclass

--- a/app/application/use_cases/skill/edit_skill.py
+++ b/app/application/use_cases/skill/edit_skill.py
@@ -72,6 +72,9 @@ class EditSkillUseCase(ICommandUseCase[EditSkillRequest, SkillResponse]):
             level=request.level,
         )
 
+        if request.order_index is not None:
+            skill.update_order(request.order_index)
+
         # Persist changes
         updated_skill = await self.skill_repo.update(skill)
 

--- a/tests/unit/api/test_skill_router.py
+++ b/tests/unit/api/test_skill_router.py
@@ -78,6 +78,40 @@ class TestUpdateSkill:
         response = await client.put(f"{PREFIX}/nonexistent", json=payload)
         assert response.status_code == 404
 
+    @pytest.mark.unit
+    async def test_update_skill_with_order_index_returns_200(self, client: AsyncClient):
+        """PUT with order_index in body must be accepted and return 200."""
+        payload = {"order_index": 5}
+        response = await client.put(f"{PREFIX}/skill_001", json=payload)
+        assert response.status_code == 200
+
+    @pytest.mark.unit
+    async def test_update_skill_with_all_fields_returns_200(self, client: AsyncClient):
+        """PUT with name, level and order_index together must return 200."""
+        payload = {"name": "Rust", "level": "expert", "order_index": 3}
+        response = await client.put(f"{PREFIX}/skill_001", json=payload)
+        assert response.status_code == 200
+
+    @pytest.mark.unit
+    async def test_update_skill_order_index_negative_returns_422(
+        self, client: AsyncClient
+    ):
+        """order_index < 0 must be rejected at the schema level (422)."""
+        payload = {"order_index": -1}
+        response = await client.put(f"{PREFIX}/skill_001", json=payload)
+        assert response.status_code == 422
+
+    @pytest.mark.unit
+    async def test_update_skill_response_contains_order_index(
+        self, client: AsyncClient
+    ):
+        """Response body must include the order_index field."""
+        payload = {"order_index": 0}
+        response = await client.put(f"{PREFIX}/skill_001", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "order_index" in data
+
 
 class TestDeleteSkill:
     async def test_delete_skill_returns_200(self, client: AsyncClient):

--- a/tests/unit/application/dto/test_skill_dto.py
+++ b/tests/unit/application/dto/test_skill_dto.py
@@ -1,6 +1,12 @@
 """Tests for Skill DTOs."""
 
-from app.application.dto.skill_dto import SkillListResponse, SkillResponse
+import pytest
+
+from app.application.dto.skill_dto import (
+    EditSkillRequest,
+    SkillListResponse,
+    SkillResponse,
+)
 
 from .conftest import DT, DT2, make_entity
 
@@ -15,6 +21,42 @@ def _make_skill_entity(**overrides):
     }
     defaults.update(overrides)
     return make_entity(**defaults)
+
+
+class TestEditSkillRequest:
+    @pytest.mark.unit
+    def test_order_index_defaults_to_none(self):
+        """order_index is optional — must default to None."""
+        req = EditSkillRequest(skill_id="s-1")
+        assert req.order_index is None
+
+    @pytest.mark.unit
+    def test_accepts_order_index_when_provided(self):
+        """order_index is accepted when explicitly supplied."""
+        req = EditSkillRequest(skill_id="s-1", order_index=7)
+        assert req.order_index == 7
+
+    @pytest.mark.unit
+    def test_all_fields_optional_except_skill_id(self):
+        """Only skill_id is required; name and level also default to None."""
+        req = EditSkillRequest(skill_id="s-99")
+        assert req.name is None
+        assert req.level is None
+        assert req.order_index is None
+
+    @pytest.mark.unit
+    def test_full_construction(self):
+        """All fields provided together are stored correctly."""
+        req = EditSkillRequest(
+            skill_id="s-1",
+            name="Go",
+            level="advanced",
+            order_index=3,
+        )
+        assert req.skill_id == "s-1"
+        assert req.name == "Go"
+        assert req.level == "advanced"
+        assert req.order_index == 3
 
 
 class TestSkillResponseFromEntity:

--- a/tests/unit/application/use_cases/test_skill_use_cases.py
+++ b/tests/unit/application/use_cases/test_skill_use_cases.py
@@ -137,6 +137,63 @@ class TestEditSkillUseCase:
 
         repo.exists_by_name.assert_not_awaited()
 
+    @pytest.mark.unit
+    async def test_edit_skill_with_order_index_calls_update_order(self):
+        """When order_index is provided it must be propagated via update_order."""
+        repo = AsyncMock()
+        skill = _make_skill(order_index=0)
+        repo.get_by_id.return_value = skill
+        repo.exists_by_name.return_value = False
+        repo.update.return_value = skill
+
+        uc = EditSkillUseCase(repo)
+        request = EditSkillRequest(skill_id="skill-001", order_index=5)
+        await uc.execute(request)
+
+        assert skill.order_index == 5
+        repo.update.assert_awaited_once()
+
+    @pytest.mark.unit
+    async def test_edit_skill_without_order_index_does_not_change_order(self):
+        """When order_index is None, update_order must NOT be called."""
+        repo = AsyncMock()
+        skill = _make_skill(order_index=3)
+        repo.get_by_id.return_value = skill
+        repo.exists_by_name.return_value = False
+        repo.update.return_value = skill
+
+        uc = EditSkillUseCase(repo)
+        request = EditSkillRequest(skill_id="skill-001", name="Rust", order_index=None)
+        await uc.execute(request)
+
+        # order_index must remain unchanged
+        assert skill.order_index == 3
+        repo.update.assert_awaited_once()
+
+    @pytest.mark.unit
+    async def test_edit_skill_combined_name_level_order_index(self):
+        """Updating name, level and order_index together must apply all changes."""
+        repo = AsyncMock()
+        skill = _make_skill(name="Python", level="basic", order_index=0)
+        repo.get_by_id.return_value = skill
+        repo.exists_by_name.return_value = False
+        repo.update.return_value = skill
+
+        uc = EditSkillUseCase(repo)
+        request = EditSkillRequest(
+            skill_id="skill-001",
+            name="Rust",
+            level="expert",
+            order_index=10,
+        )
+        result = await uc.execute(request)
+
+        assert skill.name == "Rust"
+        assert skill.level == "expert"
+        assert skill.order_index == 10
+        repo.update.assert_awaited_once()
+        assert result.name == "Rust"
+
 
 class TestListSkillsUseCase:
     async def test_list_skills_all(self):


### PR DESCRIPTION
EditSkillRequest DTO, EditSkillUseCase, and skill_router were not passing order_index when updating a skill, causing the field to be silently ignored on PUT requests.