### PR TITLE
fix: pass technologies field in additional-training router

### DIFF
--- a/app/api/v1/routers/additional_training_router.py
+++ b/app/api/v1/routers/additional_training_router.py
@@ -90,6 +90,7 @@ async def create_additional_training(
             duration=training_data.duration,
             certificate_url=training_data.certificate_url,
             description=training_data.description,
+            technologies=training_data.technologies,
         )
     )
     return result
@@ -117,6 +118,7 @@ async def update_additional_training(
             duration=training_data.duration,
             certificate_url=training_data.certificate_url,
             description=training_data.description,
+            technologies=training_data.technologies,
         )
     )
     return result


### PR DESCRIPTION
  The POST and PUT handlers were not forwarding when building the request DTO, silently dropping the field before it reached the use case or persistence layer.

